### PR TITLE
#1 - Implemented sameObjectAs() Matcher

### DIFF
--- a/source/brsHamcrest_Assert.brs
+++ b/source/brsHamcrest_Assert.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Shortcut to assertThat, designed for readability when using existing assertion functions (such as with brstest)

--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -22,7 +22,8 @@ function HamcrestOptions () as Object
     return globalAA.brsHamcrestOptionsSingleton
 end function
 
-'Stop code execution and display an error message
+
+'Output an error message to the console, and cause a BrightScript STOP if option is set
 '
 '@param message {String} the error message to display
 '@return {String} the error message as it was output to the console. Returns Invalid if nothing was output.

--- a/source/brsHamcrest_Matchers/brsHamcrest_CollectionMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_CollectionMatchers.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Matcher to test the given collection contains zero elements

--- a/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Decorates another Matcher, retaining its behaviour, but allowing tests to be slightly more expressive.

--- a/source/brsHamcrest_Matchers/brsHamcrest_NumericMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_NumericMatchers.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Matcher to test the given number is close to a value, within the given delta

--- a/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
@@ -16,15 +16,15 @@ function sameObjectAs (value as Object) as Object
     matcher.value = value
 
     matcher.doMatch = function (target as Dynamic) as Boolean
-        if (HasInterface(target, "ifAssociativeArray") AND HasInterface(value, "ifAssociativeArray"))
+        if (HasInterface(target, "ifAssociativeArray") AND HasInterface(m.value, "ifAssociativeArray"))
             result = False
             deviceInfo = CreateObject("roDeviceInfo")
             uuidKey = "brsHamcrestUUID"
             uuidValue = deviceInfo.GetRandomUUID()
             target.AddReplace(uuidKey, uuidValue)
-            if (value.Lookup(uuidKey) = uuidValue) then result = True
+            if (m.value.Lookup(uuidKey) = uuidValue) then result = True
             target.Delete(uuidKey)
-            value.Delete(uuidKey)
+            m.value.Delete(uuidKey)
             return result
         else
             HamcrestError("Type Mismatch: Both target and value must be object types (implement ifAssociativeArray).")

--- a/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
@@ -1,0 +1,37 @@
+' #################################################################
+' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
+' #################################################################
+
+
+'Matcher to test that two references are using the same object instance
+'
+'Example:
+'assertThat(foo, is(sameObjectAs(bar)))
+'
+'@param value {Object} The object to compare against
+'@return {Object<Matcher>} A Matcher
+function sameObjectAs (value as Object) as Object
+    matcher = BaseMatcher()
+
+    matcher.value = value
+
+    matcher.doMatch = function (target as Dynamic) as Boolean
+        if (isEnumerable(target) AND isEnumerable(value))
+            result = False
+            deviceInfo = CreateObject("roDeviceInfo")
+            uuidKey = "brsHamcrestUUID"
+            uuidValue = deviceInfo.GetRandomUUID()
+            value.Delete(uuidKey)
+            target.AddReplace(uuidKey, uuidValue)
+            if (value.Lookup(uuidKey) = uuidValue) then result = True
+            target.Delete(uuidKey)
+            value.Delete(uuidKey)
+            return result
+        else
+            HamcrestError("Type Mismatch: Both target and value must be enumerable types.")
+            return False
+        end if
+    end function
+
+    return matcher
+end function

--- a/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
@@ -16,19 +16,18 @@ function sameObjectAs (value as Object) as Object
     matcher.value = value
 
     matcher.doMatch = function (target as Dynamic) as Boolean
-        if (isEnumerable(target) AND isEnumerable(value))
+        if (HasInterface(target, "ifAssociativeArray") AND HasInterface(value, "ifAssociativeArray"))
             result = False
             deviceInfo = CreateObject("roDeviceInfo")
             uuidKey = "brsHamcrestUUID"
             uuidValue = deviceInfo.GetRandomUUID()
-            value.Delete(uuidKey)
             target.AddReplace(uuidKey, uuidValue)
             if (value.Lookup(uuidKey) = uuidValue) then result = True
             target.Delete(uuidKey)
             value.Delete(uuidKey)
             return result
         else
-            HamcrestError("Type Mismatch: Both target and value must be enumerable types.")
+            HamcrestError("Type Mismatch: Both target and value must be object types (implement ifAssociativeArray).")
             return False
         end if
     end function

--- a/source/brsHamcrest_Matchers/brsHamcrest_TextMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_TextMatchers.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Matcher to test a value contains a given String

--- a/source/brsHamcrest_Matchers/brsHamcrest_TypeMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_TypeMatchers.brs
@@ -1,7 +1,6 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
 
 
 'Matcher to test the type is an Array

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Assert.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Assert.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CollectionMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CollectionMatchers.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CoreMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CoreMatchers.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_NumericMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_NumericMatchers.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
@@ -1,0 +1,107 @@
+' #################################################################
+' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
+' #################################################################
+
+
+' SETUP / TEARDOWN
+
+'Set up the unit tests
+'
+'@return {Object} The test helper
+function setup_brsHamcrest_ObjectMatchers () as Object
+    test = {
+    }
+    return test
+end function
+
+'Clean up after running a unit test
+function teardown_brsHamcrest_ObjectMatchers () as Void
+
+end function
+
+' UNIT TESTS
+
+' sameObjectAs()
+sub test_sameObjectAs_sharedInstance (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = {foo: "bar"}
+    testValue = testTarget
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_differentInstances (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = {foo: "bar"}
+    testValue = {bar: "foo"}
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_targetIsNotObject (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = "foo"
+    testValue = {foo: "bar"}
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_valueIsNotObject (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = {foo: "bar"}
+    testValue = "foo"
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_targetAndValueAreNotObjects (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = 123
+    testValue = "foo"
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
@@ -34,6 +34,8 @@ sub test_sameObjectAs_sharedInstance (t as Object)
 
     'THEN'
     t.assertTrue(result)
+    t.assertEqual(testTarget.Keys().count(), 1)
+    t.assertEqual(testValue.Keys().count(), 1)
 
     teardown_brsHamcrest_ObjectMatchers()
 end sub
@@ -51,6 +53,8 @@ sub test_sameObjectAs_differentInstances (t as Object)
 
     'THEN'
     t.assertFalse(result)
+    t.assertEqual(testTarget.Keys().count(), 1)
+    t.assertEqual(testValue.Keys().count(), 1)
 
     teardown_brsHamcrest_ObjectMatchers()
 end sub
@@ -68,6 +72,7 @@ sub test_sameObjectAs_targetIsNotObject (t as Object)
 
     'THEN'
     t.assertFalse(result)
+    t.assertEqual(testValue.Keys().count(), 1)
 
     teardown_brsHamcrest_ObjectMatchers()
 end sub
@@ -85,6 +90,7 @@ sub test_sameObjectAs_valueIsNotObject (t as Object)
 
     'THEN'
     t.assertFalse(result)
+    t.assertEqual(testTarget.Keys().count(), 1)
 
     teardown_brsHamcrest_ObjectMatchers()
 end sub

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_TextMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_TextMatchers.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_TypeMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_TypeMatchers.brs
@@ -1,7 +1,7 @@
 ' #################################################################
 ' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
 ' #################################################################
-'                 Copyright (c) 2016 Benjamin Hill
+
 
 ' SETUP / TEARDOWN
 

--- a/tests/source/brsHamcrest/fakeBaseMatcher.brs
+++ b/tests/source/brsHamcrest/fakeBaseMatcher.brs
@@ -1,3 +1,11 @@
+' #################################################################
+' ###   brsHamcrest   ###   github.com/imbenjamin/brsHamcrest   ###
+' #################################################################
+
+
+'Mock BaseMatcher class, manually set willMatch for unit testing
+'
+'@return {Object} Mock BaseMatcher
 function FakeBaseMatcher () as Object
     fake = {
         CLASS_TYPE: "Matcher"


### PR DESCRIPTION
Closes #1 by implementing `sameObjectAs()` as the first Object Matcher in `brsHamcrest_ObjectMatchers.brs`.