### PR TITLE
Closes #8 by implementing shortcuts in is() and isNot()

### DIFF
--- a/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
@@ -4,25 +4,32 @@
 
 
 'Decorates another Matcher, retaining its behaviour, but allowing tests to be slightly more expressive.
+'If passed an array, then is() acts as a shortcut to allOf()
 '
 'Example:
 'assertThat(foo, is(aString()))
+'assertThat(foo, is([aString(), endsWithString("bar")]))
 '
 '@param matcher {Object<Matcher>} A Matcher
 '@return {Object<Matcher>} A Matcher
 function is (matcher as Object) as Object
+    if type(matcher) = "roArray" then return allOf(matcher)
     return matcher
 end function
 
 
 'Creates a matcher that wraps an existing matcher, but inverts the logic by which it will match.
+'If passed an array, isNot() acts as a shortcut to noneOf()
 '
 'Example:
 'assertThat(foo, isNot(aString()))
+'assertThat(foo, isNot([aString(), aNumber()]))
 '
 '@param matcher {Object<Matcher>} A Matcher
 '@return {Object<Matcher>} A Matcher
 function isNot (matcher as Object) as Object
+    if type(matcher) = "roArray" then return noneOf(matcher)
+
     retVal = Invalid
     if (matcher.CLASS_TYPE = "Matcher")
         newMatcher = matcher

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CoreMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_CoreMatchers.brs
@@ -57,6 +57,66 @@ sub test_is_matcherFalse (t as Object)
 end sub
 
 
+sub test_is_arrayTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = true
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = true
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = is(matcherArray).doMatch(dummyTarget)
+
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
+sub test_is_arraySomeTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = true
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = false
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = is(matcherArray).doMatch(dummyTarget)
+
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
+sub test_is_arrayNoneTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = false
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = false
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = is(matcherArray).doMatch(dummyTarget)
+
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
 'isNot()
 sub test_isNot_matcherTrueResultFalse (t as Object)
     test = setup_brsHamcrest_CoreMatchers()
@@ -86,6 +146,66 @@ sub test_isNot_matcherFalseResultTrue (t as Object)
     result = isNot(matcher).doMatch(test.knownString)
 
     'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
+sub test_isNot_arrayTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = true
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = true
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = isNot(matcherArray).doMatch(dummyTarget)
+
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
+sub test_isNot_arraySomeTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = true
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = false
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = isNot(matcherArray).doMatch(dummyTarget)
+
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_CoreMatchers()
+end sub
+
+
+sub test_isNot_arrayNoneTrue (t as Object)
+    test = setup_brsHamcrest_CoreMatchers()
+
+    'GIVEN'
+    dummyTarget = {}
+    matcher1 = FakeBaseMatcher()
+    matcher1.willMatch = false
+    matcher2 = FakeBaseMatcher()
+    matcher2.willMatch = false
+    matcherArray = [matcher1, matcher2]
+
+    'WHEN'
+    result = isNot(matcherArray).doMatch(dummyTarget)
+
     t.assertTrue(result)
 
     teardown_brsHamcrest_CoreMatchers()


### PR DESCRIPTION
Closes #8 by implementing shortcuts in is() and isNot() to allOf() and noneOf() respectively