### PR TITLE
Fixed issues in coreDoMatch comparison (#24)

### DIFF
--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -64,8 +64,8 @@ end function
 '@param obj {Dynamic} the comparison to compare against
 '@return {Boolean} true if the target and comparison are identical
 function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
-    targetType = type(target)
-    comparisonType = type(comparison)
+    targetType = BrsHamcrestNormaliseType(type(target))
+    comparisonType = BrsHamcrestNormaliseType(type(comparison))
 
     if (targetType = comparisonType)
 
@@ -84,7 +84,7 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
             if (targetItemCount = comparisonItems.Count())
 
                 for i=0 to targetItemCount-1 step 1
-                    if (targetItems[i].key <> comparisonItems[i].key)
+                    if (LCase(targetItems[i].key) <> LCase(comparisonItems[i].key))
                         return false
                     else
                         if (coreDoMatch(targetItems[i].value, comparisonItems[i].value) = false) return false
@@ -108,4 +108,35 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
     end if
 
     return true
+end function
+
+
+'Return a normalised type-value to handle the fact that calling type(target) can vary in the actual type-value returned.
+'
+'@param typeIn {String} the type-value to normalise
+'@return {String} the normalised type-value
+function BrsHamcrestNormaliseType (typeIn as String) as String
+
+        types = {
+            roArray: "roArray"
+            roAssociativeArray: "roAssociativeArray"
+            roBoolean: "roBoolean"
+            Boolean: "roBoolean"
+            roDouble: "roDouble"
+            Double: "roDouble"
+            roIntrinsicDouble: "roDouble"
+            roFloat: "roFloat"
+            Float: "roFloat"
+            roFunction: "roFunction"
+            Function: "roFunction"
+            roInteger: "roInteger"
+            roInt: "roInteger"
+            Integer: "roInteger"
+            roLongInteger: "roLongInteger"
+            LongInteger: "roLongInteger"
+            roString: "roString"
+            String: "roString"
+        }
+
+        return types[typeIn]
 end function

--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -138,5 +138,12 @@ function BrsHamcrestNormaliseType (typeIn as String) as String
             String: "roString"
         }
 
-        return types[typeIn]
+        if (types.DoesExist(typeIn))
+            typeOut = types[typeIn]
+        else
+            HamcrestError("Unsupported type cannot be normalised")
+            typeOut = "<ERROR:UNSUPPORTED_TYPE>"
+        end if
+
+        return typeOut
 end function

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -162,7 +162,7 @@ end sub
 
 ' IsEnumerable()
 sub test_IsEnumerable_true (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     foo = CreateObject("roAssociativeArray")
@@ -177,7 +177,7 @@ sub test_IsEnumerable_true (t as Object)
 end sub
 
 sub test_IsEnumerable_false (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     foo = CreateObject("roDateTime")
@@ -193,7 +193,7 @@ end sub
 
 
 sub test_coreDoMatch_withIdenticalDataTypes (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -216,7 +216,7 @@ end sub
 
 
 sub test_coreDoMatch_withDifferentDataTypes (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -245,7 +245,7 @@ end sub
 
 
 sub test_coreDoMatch_withSameKeysDifferentValues (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -273,7 +273,7 @@ end sub
 
 
 sub test_coreDoMatch_withIdenticalAPI (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -296,7 +296,7 @@ end sub
 
 
 sub test_coreDoMatch_withDifferentAPI (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -323,7 +323,7 @@ end sub
 
 
 sub test_coreDoMatch_withIdenticalCollectionDataTypes (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -345,7 +345,7 @@ end sub
 
 
 sub test_coreDoMatch_withdifferentCollectionData (t as Object)
-    test = setup_brsHamcrest_Helpers
+    test = setup_brsHamcrest_Helpers()
 
     'GIVEN'
     getFooObj = function () as Object
@@ -364,6 +364,73 @@ sub test_coreDoMatch_withdifferentCollectionData (t as Object)
     result = coreDoMatch(target, comparison)
     'THEN'
     t.assertFalse(result)
+
+    teardown_brsHamcrest_Helpers()
+end sub
+
+
+sub test_coreDoMatch_withNonStrictTypeMatching (t as Object)
+    test = setup_brsHamcrest_Helpers()
+
+    'GIVEN'
+    target = {
+        propString: "foo"
+        propBoolean: true
+        propInteger: 2
+        propNumber:  1.2345
+    }
+    'XXX: Parsing the object as a json string will create non-strict types (e.g. "String"
+    '     instead of "roString"). But these properties should still actually match.
+    comparison = ParseJson("{""propString"": ""foo"",""propBoolean"": true,""propInteger"": 2,""propNumber"": 1.2345}")
+    'WHEN'
+    result = coreDoMatch(target, comparison)
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_Helpers()
+end sub
+
+
+sub test_BrsHamcrestNormaliseType_normaliseAllTypes (t as Object)
+    test = setup_brsHamcrest_Helpers()
+
+    'WHEN'
+    normalisedRoArrayType = BrsHamcrestNormaliseType("roArray")
+    normalisedRoAssocArrayType = BrsHamcrestNormaliseType("roAssociativeArray")
+    normalisedRoBooleanType = BrsHamcrestNormaliseType("roBoolean")
+    normalisedBooleanType = BrsHamcrestNormaliseType("Boolean")
+    normalisedRoDoubleType = BrsHamcrestNormaliseType("roDouble")
+    normalisedDoubleType = BrsHamcrestNormaliseType("Double")
+    normalisedRoIntrinsicDoubleType = BrsHamcrestNormaliseType("roIntrinsicDouble")
+    normalisedRoFloatType = BrsHamcrestNormaliseType("roFloat")
+    normalisedFloatType = BrsHamcrestNormaliseType("Float")
+    normalisedRoFunctionType = BrsHamcrestNormaliseType("roFunction")
+    normalisedFunctionType = BrsHamcrestNormaliseType("Function")
+    normalisedRoIntegerType = BrsHamcrestNormaliseType("roInteger")
+    normalisedRoIntType = BrsHamcrestNormaliseType("roInt")
+    normalisedIntegerType = BrsHamcrestNormaliseType("Integer")
+    normalisedRoLongIntegerType = BrsHamcrestNormaliseType("roLongInteger")
+    normalisedLongIntegerType = BrsHamcrestNormaliseType("LongInteger")
+    normalisedStringType = BrsHamcrestNormaliseType("String")
+    normalisedRoStringType = BrsHamcrestNormaliseType("roString")
+
+    'THEN'
+    t.assertEqual("roArray", normalisedRoArrayType)
+    t.assertEqual("roAssociativeArray", normalisedRoAssocArrayType)
+    t.assertEqual("roDouble", normalisedRoDoubleType)
+    t.assertEqual("roDouble", normalisedDoubleType)
+    t.assertEqual("roDouble", normalisedRoIntrinsicDoubleType)
+    t.assertEqual("roFloat", normalisedRoFloatType)
+    t.assertEqual("roFloat", normalisedFloatType)
+    t.assertEqual("roFunction", normalisedRoFunctionType)
+    t.assertEqual("roFunction", normalisedFunctionType)
+    t.assertEqual("roInteger", normalisedRoIntegerType)
+    t.assertEqual("roInteger", normalisedRoIntType)
+    t.assertEqual("roInteger", normalisedIntegerType)
+    t.assertEqual("roLongInteger", normalisedRoLongIntegerType)
+    t.assertEqual("roLongInteger", normalisedLongIntegerType)
+    t.assertEqual("roString", normalisedStringType)
+    t.assertEqual("roString", normalisedRoStringType)
 
     teardown_brsHamcrest_Helpers()
 end sub

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -391,7 +391,7 @@ sub test_coreDoMatch_withNonStrictTypeMatching (t as Object)
 end sub
 
 
-sub test_BrsHamcrestNormaliseType_normaliseAllTypes (t as Object)
+sub test_BrsHamcrestNormaliseType_normaliseAllKnownTypes (t as Object)
     test = setup_brsHamcrest_Helpers()
 
     'WHEN'
@@ -431,6 +431,19 @@ sub test_BrsHamcrestNormaliseType_normaliseAllTypes (t as Object)
     t.assertEqual("roLongInteger", normalisedLongIntegerType)
     t.assertEqual("roString", normalisedStringType)
     t.assertEqual("roString", normalisedRoStringType)
+
+    teardown_brsHamcrest_Helpers()
+end sub
+
+
+sub test_BrsHamcrestNormaliseType_normaliseUnknownTypes (t as Object)
+    test = setup_brsHamcrest_Helpers()
+
+    'WHEN'
+    normalisedUnknownType = BrsHamcrestNormaliseType("unknownType")
+
+    'THEN'
+    t.assertEqual(normalisedUnknownType, "<ERROR:UNSUPPORTED_TYPE>")
 
     teardown_brsHamcrest_Helpers()
 end sub


### PR DESCRIPTION
Fixed issue where `coreDoMatch` was not correctly matching comparison objects when the type strings don't specifically match (#24).

Also fixed an issue where the name of an object key is not lower cased as expected (#25).

Both issues occur when one of the comparison objects was created with the `ParseJson()` inbuilt BrightScript method).