### PR TITLE
[#28] Use custom getItems() method

### DIFF
--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -67,6 +67,17 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
     targetType = BrsHamcrestNormaliseType(type(target))
     comparisonType = BrsHamcrestNormaliseType(type(comparison))
 
+    'XXX: This inline function replaces the use of the native ifAssociativeArray.items(),
+    '     which can actually be overwritten and therefore unavailable. This often occurs, 
+    '     for example, when parsing json data.
+    _getItems = function (target as Object) as Object
+        items = []
+        for each item in target
+            items.push({key:item,value:target[item]})
+        end for
+        return items
+    end function
+
     if (targetType = comparisonType)
 
         if (targetType = "roArray")
@@ -78,8 +89,8 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
                 return false
             end if
         else if (targetType = "roAssociativeArray")
-            targetItems = target.items()
-            comparisonItems = comparison.items()
+            targetItems = _getItems(target)
+            comparisonItems = _getItems(comparison)
             targetItemCount = targetItems.Count()
             if (targetItemCount = comparisonItems.Count())
 

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -391,6 +391,30 @@ sub test_coreDoMatch_withNonStrictTypeMatching (t as Object)
 end sub
 
 
+sub test_coreDoMatch_withItemsApiMethodOverwritten (t as Object)
+    test = setup_brsHamcrest_Helpers()
+
+    'GIVEN'
+    getFooObj = function () as Object
+        return {
+            items: ["item1","item2","item3"]
+            knownString: "knownStringParam"
+            knownInteger: 1
+            knownBoolean: true
+            knownFloat: 1/3
+            knownDouble: 2.3#
+            knownLongInteger: 987654321&
+        }
+    end function
+    'WHEN'
+    result = coreDoMatch(getFooObj(), getFooObj())
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_Helpers()
+end sub
+
+
 sub test_BrsHamcrestNormaliseType_normaliseAllKnownTypes (t as Object)
     test = setup_brsHamcrest_Helpers()
 


### PR DESCRIPTION
Fixes #28 by replacing the use of obj.items() with a local method that performs the same task.