### PR TITLE
35_lexicographical_key_ordering

### DIFF
--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -67,19 +67,7 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
     targetType = BrsHamcrestNormaliseType(type(target))
     comparisonType = BrsHamcrestNormaliseType(type(comparison))
 
-    'XXX: This inline function replaces the use of the native ifAssociativeArray.items(),
-    '     which can actually be overwritten and therefore unavailable. This often occurs, 
-    '     for example, when parsing json data.
-    _getItems = function (target as Object) as Object
-        items = []
-        for each item in target
-            items.push({key:item,value:target[item]})
-        end for
-        return items
-    end function
-
     if (targetType = comparisonType)
-
         if (targetType = "roArray")
             if (target.count() = comparison.count())
                 for i=0 to target.count()-1 Step 1
@@ -89,17 +77,9 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
                 return false
             end if
         else if (targetType = "roAssociativeArray")
-            targetItems = _getItems(target)
-            comparisonItems = _getItems(comparison)
-            targetItemCount = targetItems.Count()
-            if (targetItemCount = comparisonItems.Count())
-
-                for i=0 to targetItemCount-1 step 1
-                    if (LCase(targetItems[i].key) <> LCase(comparisonItems[i].key))
-                        return false
-                    else
-                        if (coreDoMatch(targetItems[i].value, comparisonItems[i].value) = false) return false
-                    end if
+            if (target.Count() = comparison.Count())
+                for each key in target
+                    if (coreDoMatch(target.LookupCI(key), comparison.LookupCI(key)) = false) return false
                 end for
             else
                 return false

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -423,43 +423,43 @@ sub test_coreDoMatch_targetAndValueAreIdenticalObjects_withDifferentKeyOrder (t 
 
     'GIVEN'
     testTarget = {
-        active: false
-        buttonid: "14_DAYS_CINEMA_TRIAL"
-        buttontext: "Start free trial"
-        category: "CINEMA"
-        colour: "#HEX111"
-        index: 0
-        itemtype: "TRIAL_SUBSCRIPTION"
-        offerid: "C_003088"
-        priceIncreaseMessage: "Movies trial Price increase message"
-        priceIncreasePrice: 20.99
-        priceIncreaseText: "Movies trial price increase text"
-        queued: false
-        sectionnavigation: "MOVIES"
-        statustext: "Start your 14 day free trial"
-        ticketuri: "pkg:/images/account/movies_inactive.png"
-        title: "Sky Cinema 14 Days Trial"
-        trial: true
+        lorem: false
+        ipsum: "dolor sit amet"
+        consectetur: "adipiscing elit"
+        sed: "do"
+        eiusmod: "tempor"
+        incididunt: 0
+        ut: "labore et dolore"
+        magna : "aliqua"
+        enim: "ad minim veniam"
+        quis: 20.99
+        nostrud: "exercitation ullamco laboris"
+        nisi: false
+        aliquip: "ex ea commodo"
+        consequat: "Duis aute irure dolor"
+        reprehenderit: "in voluptate velit esse "
+        cillum: "dolore eu fugiat nulla"
+        pariatur: true
     }
 
     testValue = {
-        itemtype: "TRIAL_SUBSCRIPTION"
-        buttonid: "14_DAYS_CINEMA_TRIAL"
-        category: "CINEMA"
-        priceIncreaseMessage: "Movies trial Price increase message"
-        buttontext: "Start free trial"
-        colour: "#HEX111"
-        offerid: "C_003088"
-        index: 0
-        trial: true
-        title: "Sky Cinema 14 Days Trial"
-        statustext: "Start your 14 day free trial"
-        priceIncreasePrice: 20.99
-        priceIncreaseText: "Movies trial price increase text"
-        queued: false
-        active: false
-        sectionnavigation: "MOVIES"
-        ticketuri: "pkg:/images/account/movies_inactive.png"
+        consectetur: "adipiscing elit"
+        lorem: false
+        pariatur: true
+        sed: "do"
+        cillum: "dolore eu fugiat nulla"
+        eiusmod: "tempor"
+        nostrud: "exercitation ullamco laboris"
+        reprehenderit: "in voluptate velit esse "
+        ut: "labore et dolore"
+        consequat: "Duis aute irure dolor"
+        magna : "aliqua"
+        aliquip: "ex ea commodo"
+        nisi: false
+        ipsum: "dolor sit amet"
+        enim: "ad minim veniam"
+        quis: 20.99
+        incididunt: 0
     }
 
     'WHEN'

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -415,6 +415,63 @@ sub test_coreDoMatch_withItemsApiMethodOverwritten (t as Object)
 end sub
 
 
+
+
+
+sub test_coreDoMatch_targetAndValueAreIdenticalObjects_withDifferentKeyOrder (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = {
+        active: false
+        buttonid: "14_DAYS_CINEMA_TRIAL"
+        buttontext: "Start free trial"
+        category: "CINEMA"
+        colour: "#HEX111"
+        index: 0
+        itemtype: "TRIAL_SUBSCRIPTION"
+        offerid: "C_003088"
+        priceIncreaseMessage: "Movies trial Price increase message"
+        priceIncreasePrice: 20.99
+        priceIncreaseText: "Movies trial price increase text"
+        queued: false
+        sectionnavigation: "MOVIES"
+        statustext: "Start your 14 day free trial"
+        ticketuri: "pkg:/images/account/movies_inactive.png"
+        title: "Sky Cinema 14 Days Trial"
+        trial: true
+    }
+
+    testValue = {
+        itemtype: "TRIAL_SUBSCRIPTION"
+        buttonid: "14_DAYS_CINEMA_TRIAL"
+        category: "CINEMA"
+        priceIncreaseMessage: "Movies trial Price increase message"
+        buttontext: "Start free trial"
+        colour: "#HEX111"
+        offerid: "C_003088"
+        index: 0
+        trial: true
+        title: "Sky Cinema 14 Days Trial"
+        statustext: "Start your 14 day free trial"
+        priceIncreasePrice: 20.99
+        priceIncreaseText: "Movies trial price increase text"
+        queued: false
+        active: false
+        sectionnavigation: "MOVIES"
+        ticketuri: "pkg:/images/account/movies_inactive.png"
+    }
+
+    'WHEN'
+    result = coreDoMatch(testTarget, testValue)
+
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
 sub test_BrsHamcrestNormaliseType_normaliseAllKnownTypes (t as Object)
     test = setup_brsHamcrest_Helpers()
 


### PR DESCRIPTION
Fixed #35 by switching to a non-ordered-array approach access to AssocArray keys. This avoids ever getting into the need to make sure the array of keys is in lexicographical order.