### PR TITLE
35_lexicographical_key_ordering

### DIFF
--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -67,19 +67,7 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
     targetType = BrsHamcrestNormaliseType(type(target))
     comparisonType = BrsHamcrestNormaliseType(type(comparison))
 
-    'XXX: This inline function replaces the use of the native ifAssociativeArray.items(),
-    '     which can actually be overwritten and therefore unavailable. This often occurs, 
-    '     for example, when parsing json data.
-    _getItems = function (target as Object) as Object
-        items = []
-        for each item in target
-            items.push({key:item,value:target[item]})
-        end for
-        return items
-    end function
-
     if (targetType = comparisonType)
-
         if (targetType = "roArray")
             if (target.count() = comparison.count())
                 for i=0 to target.count()-1 Step 1
@@ -89,17 +77,9 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
                 return false
             end if
         else if (targetType = "roAssociativeArray")
-            targetItems = _getItems(target)
-            comparisonItems = _getItems(comparison)
-            targetItemCount = targetItems.Count()
-            if (targetItemCount = comparisonItems.Count())
-
-                for i=0 to targetItemCount-1 step 1
-                    if (LCase(targetItems[i].key) <> LCase(comparisonItems[i].key))
-                        return false
-                    else
-                        if (coreDoMatch(targetItems[i].value, comparisonItems[i].value) = false) return false
-                    end if
+            if (target.Count() = comparison.Count())
+                for each key in target
+                    if (coreDoMatch(target.LookupCI(key), comparison.LookupCI(key)) = false) return false
                 end for
             else
                 return false

--- a/source/brsHamcrest_Helpers.brs
+++ b/source/brsHamcrest_Helpers.brs
@@ -67,6 +67,17 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
     targetType = BrsHamcrestNormaliseType(type(target))
     comparisonType = BrsHamcrestNormaliseType(type(comparison))
 
+    'XXX: This inline function replaces the use of the native ifAssociativeArray.items(),
+    '     which can actually be overwritten and therefore unavailable. This often occurs, 
+    '     for example, when parsing json data.
+    _getItems = function (target as Object) as Object
+        items = []
+        for each item in target
+            items.push({key:item,value:target[item]})
+        end for
+        return items
+    end function
+
     if (targetType = comparisonType)
 
         if (targetType = "roArray")
@@ -78,8 +89,8 @@ function coreDoMatch (target as Dynamic, comparison as Dynamic) as Boolean
                 return false
             end if
         else if (targetType = "roAssociativeArray")
-            targetItems = target.items()
-            comparisonItems = comparison.items()
+            targetItems = _getItems(target)
+            comparisonItems = _getItems(comparison)
             targetItemCount = targetItems.Count()
             if (targetItemCount = comparisonItems.Count())
 

--- a/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_ObjectMatchers.brs
@@ -17,19 +17,33 @@ function sameObjectAs (value as Object) as Object
         value: value
 
         doMatch: function (target as Dynamic) as Boolean
+            result = false
             if (HasInterface(target, "ifAssociativeArray") AND HasInterface(m.value, "ifAssociativeArray"))
-                result = False
-                deviceInfo = CreateObject("roDeviceInfo")
-                uuidKey = "brsHamcrestUUID"
-                uuidValue = deviceInfo.GetRandomUUID()
-                target.AddReplace(uuidKey, uuidValue)
-                if (m.value.Lookup(uuidKey) = uuidValue) then result = True
-                target.Delete(uuidKey)
-                m.value.Delete(uuidKey)
-                return result
+                result = m._isSameObject(target, m.value)
+            else if (HasInterface(target, "ifArray") AND HasInterface(m.value, "ifArray"))
+                targetObj = {}
+                target.push(targetObj)
+                valueObj = m.value[m.value.count()-1]
+                if HasInterface(valueObj, "ifAssociativeArray") AND m._isSameObject(targetObj, valueObj)
+                    result = true
+                end if
+                target.pop()
             else
-                return False
+                result = False
             end if
+            return result
+        end function
+
+        _isSameObject: function (target as dynamic, value as dynamic) as Boolean
+            result = False
+            deviceInfo = CreateObject("roDeviceInfo")
+            uuidKey = "brsHamcrestUUID"
+            uuidValue = deviceInfo.GetRandomUUID()
+            target.AddReplace(uuidKey, uuidValue)
+            if (value.Lookup(uuidKey) = uuidValue) then result = True
+            target.Delete(uuidKey)
+            value.Delete(uuidKey)
+            return result
         end function
     })
 
@@ -51,7 +65,7 @@ function identicalTo (value as Object) as Object
         value: value
 
         doMatch: function (target as Dynamic) as Boolean
-            if (HasInterface(target, "ifAssociativeArray") AND HasInterface(m.value, "ifAssociativeArray"))
+            if (IsEnumerable(target) AND IsEnumerable(m.value))
                 return coreDoMatch(target, m.value)
             else
                 return False

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -391,6 +391,30 @@ sub test_coreDoMatch_withNonStrictTypeMatching (t as Object)
 end sub
 
 
+sub test_coreDoMatch_withItemsApiMethodOverwritten (t as Object)
+    test = setup_brsHamcrest_Helpers()
+
+    'GIVEN'
+    getFooObj = function () as Object
+        return {
+            items: ["item1","item2","item3"]
+            knownString: "knownStringParam"
+            knownInteger: 1
+            knownBoolean: true
+            knownFloat: 1/3
+            knownDouble: 2.3#
+            knownLongInteger: 987654321&
+        }
+    end function
+    'WHEN'
+    result = coreDoMatch(getFooObj(), getFooObj())
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_Helpers()
+end sub
+
+
 sub test_BrsHamcrestNormaliseType_normaliseAllKnownTypes (t as Object)
     test = setup_brsHamcrest_Helpers()
 

--- a/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
+++ b/tests/source/brsHamcrest/Test_brsHamcrest_Helpers.brs
@@ -415,6 +415,63 @@ sub test_coreDoMatch_withItemsApiMethodOverwritten (t as Object)
 end sub
 
 
+
+
+
+sub test_coreDoMatch_targetAndValueAreIdenticalObjects_withDifferentKeyOrder (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = {
+        lorem: false
+        ipsum: "dolor sit amet"
+        consectetur: "adipiscing elit"
+        sed: "do"
+        eiusmod: "tempor"
+        incididunt: 0
+        ut: "labore et dolore"
+        magna : "aliqua"
+        enim: "ad minim veniam"
+        quis: 20.99
+        nostrud: "exercitation ullamco laboris"
+        nisi: false
+        aliquip: "ex ea commodo"
+        consequat: "Duis aute irure dolor"
+        reprehenderit: "in voluptate velit esse "
+        cillum: "dolore eu fugiat nulla"
+        pariatur: true
+    }
+
+    testValue = {
+        consectetur: "adipiscing elit"
+        lorem: false
+        pariatur: true
+        sed: "do"
+        cillum: "dolore eu fugiat nulla"
+        eiusmod: "tempor"
+        nostrud: "exercitation ullamco laboris"
+        reprehenderit: "in voluptate velit esse "
+        ut: "labore et dolore"
+        consequat: "Duis aute irure dolor"
+        magna : "aliqua"
+        aliquip: "ex ea commodo"
+        nisi: false
+        ipsum: "dolor sit amet"
+        enim: "ad minim veniam"
+        quis: 20.99
+        incididunt: 0
+    }
+
+    'WHEN'
+    result = coreDoMatch(testTarget, testValue)
+
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
 sub test_BrsHamcrestNormaliseType_normaliseAllKnownTypes (t as Object)
     test = setup_brsHamcrest_Helpers()
 

--- a/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
+++ b/tests/source/brsHamcrest/brsHamcrest_Matchers/Test_brsHamcrest_ObjectMatchers.brs
@@ -22,7 +22,7 @@ end function
 ' UNIT TESTS
 
 ' sameObjectAs()
-sub test_sameObjectAs_sharedInstance (t as Object)
+sub test_sameObjectAs_sharedObjectInstance (t as Object)
     test = setup_brsHamcrest_ObjectMatchers()
 
     'GIVEN'
@@ -41,7 +41,26 @@ sub test_sameObjectAs_sharedInstance (t as Object)
 end sub
 
 
-sub test_sameObjectAs_differentInstances (t as Object)
+sub test_sameObjectAs_sharedArrayInstance (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = [{foo: "bar"}, 2, true]
+    testValue = testTarget
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertTrue(result)
+    t.assertEqual(testTarget.count(), 3)
+    t.assertEqual(testValue.count(), 3)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_differentObjectInstances (t as Object)
     test = setup_brsHamcrest_ObjectMatchers()
 
     'GIVEN'
@@ -55,6 +74,25 @@ sub test_sameObjectAs_differentInstances (t as Object)
     t.assertFalse(result)
     t.assertEqual(testTarget.Keys().count(), 1)
     t.assertEqual(testValue.Keys().count(), 1)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_sameObjectAs_differentArrayInstances (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = [{foo: "bar"}, 2, true]
+    testValue = [{foo: "bar"}, 2, true]
+
+    'WHEN'
+    result = sameObjectAs(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+    t.assertEqual(testTarget.count(), 3)
+    t.assertEqual(testValue.count(), 3)
 
     teardown_brsHamcrest_ObjectMatchers()
 end sub
@@ -114,7 +152,7 @@ end sub
 
 
 ' identicalTo()
-sub test_identicalTo_targetAndValueAreNotObjects (t as Object)
+sub test_identicalTo_targetAndValueAreNotObjectsOrArrays (t as Object)
     test = setup_brsHamcrest_ObjectMatchers()
 
     'GIVEN'
@@ -148,12 +186,46 @@ sub test_identicalTo_targetAndValueAreIdenticalObjects (t as Object)
 end sub
 
 
+sub test_identicalTo_targetAndValueAreIdenticalArrays (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = [{foo: "bar"}, 2, true]
+    testValue = [{foo: "bar"}, 2, true]
+
+    'WHEN'
+    result = identicalTo(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertTrue(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
 sub test_identicalTo_targetAndValueAreNOTIdenticalObjects (t as Object)
     test = setup_brsHamcrest_ObjectMatchers()
 
     'GIVEN'
     testTarget = {foo: "bar", two: 2, flag: true}
     testValue = {foo: "bar", two: 2, flag: false}
+
+    'WHEN'
+    result = identicalTo(testValue).doMatch(testTarget)
+
+    'THEN'
+    t.assertFalse(result)
+
+    teardown_brsHamcrest_ObjectMatchers()
+end sub
+
+
+sub test_identicalTo_targetAndValueAreNOTIdenticalArrays (t as Object)
+    test = setup_brsHamcrest_ObjectMatchers()
+
+    'GIVEN'
+    testTarget = [{foo: "bar"}, 2, true]
+    testValue = [{foo: "another bar"}, 1, true]
 
     'WHEN'
     result = identicalTo(testValue).doMatch(testTarget)


### PR DESCRIPTION
Fixes #35 by switching to a non-ordered-array approach access to AssocArray keys. This avoids ever getting into the need to make sure the array of keys is in lexicographical order. 