### PR TITLE
Fixed crash for associative arrays that contain properties with names…

### DIFF
--- a/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
+++ b/source/brsHamcrest_Matchers/brsHamcrest_CoreMatchers.brs
@@ -191,7 +191,7 @@ function equalTo(comparison as Dynamic) as Object
                         return false
                     end if
                 else if (targetType = "roAssociativeArray")
-                    if (target.Count() = m.comparison.Count())
+                    if (m._getAssocArrayPropertyCount(target) = m._getAssocArrayPropertyCount(m.comparison))
                         for each key in target
                             if (equalTo(m.comparison.LookupCI(key)).doMatch(target.LookupCI(key)) = false) return false
                         end for
@@ -213,6 +213,17 @@ function equalTo(comparison as Dynamic) as Object
             end if
 
             return true
+        end function
+
+        ' a limitation of BS is that an object can sometimes contain properties with names that happen to match the getters that are used
+        ' to deduce the size of those objects (i.e. count, items, keys), and BS can't tell them apart which causes an exception.
+        ' so here we avoid that issue by brute-force manually counting each property instead.
+        _getAssocArrayPropertyCount: function (obj as Object) as Integer
+            i = 0
+            for each key in obj
+                i++
+            end for
+            return i
         end function
 
         _normaliseType: function (typeIn as String) as String


### PR DESCRIPTION
… that match size getters.